### PR TITLE
Add Jib Maven Plugin for Docker Image Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,19 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <from>
+                        <image>openjdk:17-jdk-alpine</image>
+                    </from>
+                    <to>
+                        <image>registry.hub.docker.com/aamirxshaikh/${project.artifactId}</image>
+                    </to>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
### Description:
This pull request introduces changes to integrate the Jib Maven Plugin for building Docker images directly from the compiled Java artifacts during the Maven build process.

### Changes:
- **Add Jib Maven Plugin:** Added the `jib-maven-plugin` from `com.google.cloud.tools` with version `3.4.1`.
- **Configure Base Image:** Configured the plugin to use the `openjdk:17-jdk-alpine` base image for building the Docker image.
- **Set Target Docker Image:** Set the target Docker image to be pushed to `registry.hub.docker.com/aamirxshaikh/${project.artifactId}`.

### Purpose:
The purpose of this pull request is to streamline the deployment process by allowing the Docker image to be built and pushed to a Docker registry (in this case, Docker Hub) as part of the Maven build process. By integrating the Jib Maven Plugin, the need for a separate Dockerfile is eliminated, simplifying the build and deployment workflow.

The use of the `openjdk:17-jdk-alpine` base image ensures a lightweight and efficient Docker image, which is suitable for production deployments. With this change, developers can now easily build and distribute Docker images for the application, enabling consistent and reproducible deployments across different environments.