### PR TITLE
Add Docker Configuration Properties for Inventory Service

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,0 +1,15 @@
+server.port=8080
+
+# Logging level
+logging.level.org.springframework.security=TRACE
+
+# Eureka Server URL
+eureka.client.serviceUrl.defaultZone=http://root:root@discovery-server:8761/eureka
+
+# PostgreSQL Database Connection
+spring.datasource.url=jdbc:postgresql://postgres-inventory-service:5433/inventory
+spring.datasource.username=root
+spring.datasource.password=root
+
+# Zipkin Configuration
+management.zipkin.tracing.endpoint=http://zipkin:9411


### PR DESCRIPTION
### Description:
This pull request introduces a new configuration file specifically for running the Inventory Service in a Docker environment.

### Changes:
- **Add Docker Configuration Properties for Inventory Service:**
   - Added `application-docker.properties` file
   - Configured server port (8080)
   - Configured logging level for Spring Security
   - Configured Eureka server URL for discovery service
   - Configured PostgreSQL database connection properties
   - Configured Zipkin endpoint for distributed tracing

### Purpose:
The purpose of this pull request is to introduce a new configuration file `application-docker.properties` specifically for running the Inventory Service in a Docker environment. This file contains various configuration properties, such as the server port, logging level, Eureka server URL, PostgreSQL database connection details, and Zipkin endpoint for distributed tracing. By separating these configurations from the main `application.properties` file, it becomes easier to manage environment-specific settings and ensure smooth deployment and operation of the Inventory Service within Docker containers.